### PR TITLE
Backport setns for CentOS 6 glibc

### DIFF
--- a/src/mrb_namespace.c
+++ b/src/mrb_namespace.c
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <error.h>
 #include <features.h>
 
 #include <mruby.h>
@@ -30,7 +31,8 @@
 #endif
 
 static int setns(int fd, int nstype) {
-  return (int)syscall((long)SYS_setns, fd, nstype);
+  long ret = syscall(SYS_setns, fd, nstype);
+  return (int)ret;
 }
 #endif
 


### PR DESCRIPTION
```
$ sudo ./mruby/bin/mirb 
mirb - Embeddable Interactive Ruby Shell

> system "hostname"        
hoo.localhost
 => true
> Namespace.setns(Namespace::CLONE_NEWUTS, pid: 8489)
 => 1
> system "hostname"
udzura.jp
 => true
> exit
```