### PR TITLE
Support `clone(2)` invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: required
+
 language: c
 addons:
   apt:

--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -1,5 +1,9 @@
 MRuby::Build.new do |conf|
-  toolchain :gcc
+  if ENV['CC'] == 'clang'
+    toolchain :clang
+  else
+    toolchain :gcc
+  end
   conf.gembox 'default'
   conf.gem '../mruby-linux-namespace'
   conf.enable_test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mruby-linux-namespace   [![Build Status](https://travis-ci.org/haconiwa/mruby-linux-namespace.svg?branch=master)](https://travis-ci.org/haconiwa/mruby-linux-namespace)
 
-A mruby gem using unshare/setns to control linux namespce.
+A mruby gem using unshare/setns/clone to control linux namespaces.
 
 ## install by mrbgems
 
@@ -11,24 +11,26 @@ MRuby::Build.new do |conf|
 
   # ... (snip) ...
 
-  conf.gem :github => haconiwa/mruby-linux-namespace'
+  conf.gem :github => 'haconiwa/mruby-linux-namespace'
+  # mruby-process, mruby-exec, mruby-process-sys are also useful
 end
 ```
 
 ## example
 
 ```ruby
-> Namespace.getuid
+## Using mruby-process-sys
+> Process::Sys.getuid
  => 500
-> Namespace.getgid
+> Process::Sys.getgid
  => 500
 
 > Namespace.unshare(Namespace::CLONE_NEWUSER|Namespace::CLONE_NEWNET)
  => 0
 
-> Namespace.getuid
- => 65534
-> Namespace.getgid
+> Process::Sys.getuid
+ => 65534 ... unknown
+> Process::Sys.getgid
  => 65534
 
 > File.open('/proc/self/uid_map','wb+').write('0 500 1')
@@ -39,12 +41,20 @@ end
  => 7
 >
  => nil
-> Namespace.getuid
+> Process::Sys.getuid
  => 0
-> Namespace.getgid
+> Process::Sys.getgid
  => 0
 >
 ```
+
+### Available APIs
+
+* `Namecpace.unshare(flag)`
+* `Namecpace.setns(flag, pid: pid or fd: fd)`
+* `Namecpace.clone(flag) { #do something... e.g. exec }` - Note that `clone(2)` support is experimental/Recommended to exec() fast
+
+Please see `sample/*.rb` or `test/*.rb`
 
 ## License
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || ".travis_build_config.rb")
-MRUBY_VERSION=ENV["MRUBY_VERSION"] || "1.2.0"
+MRUBY_VERSION=ENV["MRUBY_VERSION"] || "master"
 
 file :mruby do
   cmd =  "git clone --depth=1 git://github.com/mruby/mruby.git"

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,4 +4,7 @@ MRuby::Gem::Specification.new('mruby-linux-namespace') do |spec|
 
   spec.add_test_dependency 'mruby-dir'
   spec.add_test_dependency 'mruby-process'
+  spec.add_test_dependency 'mruby-exec', github: 'haconiwa/mruby-exec'
+
+  spec.linker.libraries << 'pthread'
 end

--- a/sample/clone.rb
+++ b/sample/clone.rb
@@ -1,0 +1,6 @@
+pid = Namespace.clone(Namespace::CLONE_NEWNS|Namespace::CLONE_NEWPID) do
+  puts "=== Do remount by mount -t proc proc /proc && ps auxf"
+  exec '/bin/bash'
+end
+puts "Spawn OK: #{pid}"
+p Process.waitpid2(pid)

--- a/sample/clone_multi.rb
+++ b/sample/clone_multi.rb
@@ -1,0 +1,19 @@
+(1..3).to_a.map do |i|
+  Namespace.clone(Namespace::CLONE_NEWNS|Namespace::CLONE_NEWPID) do
+    puts "Process: ##{i}"
+    exec '/bin/sleep', (i * 5).to_s
+  end
+end
+
+loop do
+  begin
+    p(Process.waitpid2(-1))
+  rescue => e
+    if e.message.include? "waitpid failed"
+      puts "All over successfully"
+      exit 0
+    else
+      raise e
+    end
+  end
+end

--- a/sample/clone_multi.rb
+++ b/sample/clone_multi.rb
@@ -1,6 +1,7 @@
 (1..3).to_a.map do |i|
   Namespace.clone(Namespace::CLONE_NEWNS|Namespace::CLONE_NEWPID) do
     puts "Process: ##{i}"
+    system "ls -l /proc/self/ns/pid"
     exec '/bin/sleep', (i * 5).to_s
   end
 end

--- a/src/mrb_namespace.c
+++ b/src/mrb_namespace.c
@@ -188,7 +188,7 @@ struct mrb_clone_params {
   mrb_state *mrb;
   mrb_value block;
 };
-static struct mrb_clone_params* clone_params = NULL;
+static volatile struct mrb_clone_params* clone_params = NULL;
 
 static int mrb_clone_childfunc(void *params)
 {
@@ -198,14 +198,14 @@ static int mrb_clone_childfunc(void *params)
   }
 
   mrb_state *mrb = clone_params->mrb;
-  mrb_yield_with_class(mrb, clone_params->block, 0, NULL, mrb_nil_value(), mrb->object_class);
+  mrb_value ret = mrb_yield_with_class(mrb, clone_params->block, 0, NULL, mrb_nil_value(), mrb->object_class);
   /* mrb_funcall(mrb, mrb_obj_value(mrb->object_class), "puts", 1, mrb_str_new_lit(mrb, "Hello from clone")); */
 
   _exit(0);
   return 0;
 }
 
-#define STACK_SIZE 65535
+#define STACK_SIZE 4096
 
 static mrb_value mrb_namespace_clone(mrb_state *mrb, mrb_value self)
 {

--- a/src/mrb_namespace.c
+++ b/src/mrb_namespace.c
@@ -184,39 +184,22 @@ static mrb_value mrb_namespace_setns_by_pid(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(ns_count);
 }
 
-typedef struct mrb_clone_params {
+struct mrb_clone_params {
   mrb_state *mrb;
-  struct RProc *block;
-} mrb_clone_params;
-
-/* from https://github.com/mattn/mruby-thread/blob/master/src/mrb_thread.c */
-static mrb_sym migrate_sym(mrb_state *mrb, mrb_sym sym, mrb_state *mrb2)
-{
-  mrb_int len;
-  const char *p = mrb_sym2name_len(mrb, sym, &len);
-  return mrb_intern_static(mrb2, p, len);
-}
-
-static void migrate_all_symbols(mrb_state *mrb, mrb_state *mrb2)
-{
-  mrb_sym i;
-  for (i = 1; i < mrb->symidx + 1; i++) {
-    migrate_sym(mrb, i, mrb2);
-  }
-}
+  mrb_value block;
+};
+static struct mrb_clone_params* clone_params = NULL;
 
 static int mrb_clone_childfunc(void *params)
 {
-  mrb_clone_params *p;
-  mrb_state *mrb;
-  /* mrb_value result; */
+  if(!clone_params) {
+    printf("[BUG] No clone params...\n");
+    abort();
+  }
 
-  printf("Cloned...\n");
-  p = (mrb_clone_params *)params;
-  mrb = p->mrb;
-  printf("restore: %p, %p, %p\n", p, mrb, p->block);
-  //mrb_yield_with_class(p->mrb, mrb_obj_value(p->block), 0, NULL, mrb_nil_value(), p->mrb->object_class);
-  mrb_funcall(mrb, mrb_obj_value(mrb->object_class), "puts", 1, mrb_str_new_lit(mrb, "Hello from clone"));
+  mrb_state *mrb = clone_params->mrb;
+  mrb_yield_with_class(mrb, clone_params->block, 0, NULL, mrb_nil_value(), mrb->object_class);
+  /* mrb_funcall(mrb, mrb_obj_value(mrb->object_class), "puts", 1, mrb_str_new_lit(mrb, "Hello from clone")); */
 
   _exit(0);
   return 0;
@@ -226,7 +209,7 @@ static int mrb_clone_childfunc(void *params)
 
 static mrb_value mrb_namespace_clone(mrb_state *mrb, mrb_value self)
 {
-  mrb_clone_params *p;
+  struct mrb_clone_params *p;
   mrb_int flag;
   mrb_value block;
   char *stack, *stack_top;
@@ -235,13 +218,9 @@ static mrb_value mrb_namespace_clone(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "i&", &flag, &block);
 
   if (!mrb_nil_p(block)) {
-    p = (mrb_clone_params *)malloc(sizeof(mrb_clone_params));
-    p->mrb = mrb_open_allocf(mrb->allocf, mrb->allocf_ud);
-    migrate_all_symbols(mrb, p->mrb);
-    p->block = mrb_proc_new(mrb, mrb_proc_ptr(block)->body.irep);
-    p->block->target_class = p->mrb->object_class;
-
-    printf("alloc: %p, %p, %p\n", p, p->mrb, p->block);
+    p = (struct mrb_clone_params *)malloc(sizeof(struct mrb_clone_params));
+    p->mrb = mrb;
+    p->block = block;
 
     stack = malloc(STACK_SIZE);
     if (p == NULL || stack == NULL)
@@ -249,11 +228,12 @@ static mrb_value mrb_namespace_clone(mrb_state *mrb, mrb_value self)
 
     stack_top = stack + STACK_SIZE;
 
+    clone_params = p;
     pid = clone(
       mrb_clone_childfunc,
       stack_top,
       SIGCHLD|flag,
-      (void *)p);
+      NULL);
     if(pid < 0) {
       perror("clone");
       mrb_sys_fail(mrb, "clone failed");
@@ -266,7 +246,7 @@ static mrb_value mrb_namespace_clone(mrb_state *mrb, mrb_value self)
   return mrb_nil_value();
 }
 
-void mrb_mruby_namespace_gem_init(mrb_state *mrb)
+void mrb_mruby_linux_namespace_gem_init(mrb_state *mrb)
 {
   struct RClass *namespace;
   namespace = mrb_define_class(mrb, "Namespace", mrb->object_class);

--- a/test/test_clone.rb
+++ b/test/test_clone.rb
@@ -1,0 +1,21 @@
+assert("Namespace.clone") do
+  begin
+    system "mkdir -p /tmp/clone.res"
+    system "rm -rf /tmp/clone.res/*"
+
+    system "ls -l /proc/self/ns/pid > /tmp/clone.res/parent.pid.txt"
+    system "ls -l /proc/self/ns/mnt > /tmp/clone.res/parent.mnt.txt"
+
+    pid = Namespace.clone(Namespace::CLONE_NEWPID) do
+      system "ls -l /proc/self/ns/pid > /tmp/clone.res/cloned.pid.txt"
+      system "ls -l /proc/self/ns/mnt > /tmp/clone.res/cloned.mnt.txt"
+    end
+    Process.waitpid pid
+
+    ret = system "diff -q /tmp/clone.res/parent.mnt.txt /tmp/clone.res/cloned.mnt.txt >/dev/null"
+    assert_true ret
+
+    ret = system "diff -q /tmp/clone.res/parent.pid.txt /tmp/clone.res/cloned.pid.txt >/dev/null"
+    assert_false ret
+  end
+end


### PR DESCRIPTION
Please see `samles/*.rb`.

```ruby
# Namespace.clone accepts CLONE_* flags directly
pid = Namespace.clone(Namespace::CLONE_NEWNS|Namespace::CLONE_NEWPID) do
  puts "=== Do remount by mount -t proc proc /proc && ps auxf"
  exec '/bin/bash'
end
p Process.waitpid2(pid)
```

NOTE: This function is

* experimental
* intended to be used with `exec()`
* seems to be non-threadsafe