### PR TITLE
Add Namespace#nsenter with block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ compiler:
   - gcc
   - clang
 env:
-  - MRUBY_VERSION=1.2.0
   - MRUBY_VERSION=1.3.0
+  - MRUBY_VERSION=1.4.0
   - MRUBY_VERSION=master
 before_install:
   - sudo apt-get -qq update

--- a/mrblib/resolver.rb
+++ b/mrblib/resolver.rb
@@ -1,0 +1,23 @@
+module Namespace
+  FLAG_MAP = {
+    :mnt => CLONE_NEWNS,
+    :mount => CLONE_NEWNS,
+    :uts => CLONE_NEWUTS,
+    :ipc => CLONE_NEWIPC,
+    :pid => CLONE_NEWPID,
+    :net => CLONE_NEWNET,
+    :user => CLONE_NEWUSER
+  }
+  if Namespace.const_get :CLONE_NEWCGROUP
+    FLAG_MAP[:cgroup] = CLONE_NEWCGROUP
+  end
+  FLAG_MAP.freeze
+
+  def self.resolve_flag(flg_exp)
+    if flg_exp.is_a?(Integer)
+      return flg_exp
+    else
+      FLAG_MAP.fetch(flg_exp.to_sym)
+    end
+  end
+end

--- a/mrblib/resolver.rb
+++ b/mrblib/resolver.rb
@@ -8,7 +8,7 @@ module Namespace
     :net => CLONE_NEWNET,
     :user => CLONE_NEWUSER
   }
-  if Namespace.const_get :CLONE_NEWCGROUP
+  if Namespace.const_defined? :CLONE_NEWCGROUP
     FLAG_MAP[:cgroup] = CLONE_NEWCGROUP
   end
   FLAG_MAP.freeze

--- a/mrblib/setns.rb
+++ b/mrblib/setns.rb
@@ -18,7 +18,7 @@ module Namespace
   end
 
   def self.nsenter(flag, options, &blk)
-    unless Object.const_get(:Process)
+    unless Object.const_defined? :Process
       raise NotImplementedError, "Namespace.nsenter depends on mruby-process"
     end
 

--- a/mrblib/setns.rb
+++ b/mrblib/setns.rb
@@ -1,5 +1,9 @@
 module Namespace
-  def self.setns(flag, options)
+  def self.setns(flag, options, &blk)
+    if blk
+      return nsenter(flag, options, &blk)
+    end
+
     fd = options[:fd]
     pid = options[:pid]
 
@@ -10,5 +14,27 @@ module Namespace
     else
       raise ArgumentError, "Options :fd or :pid must be specified"
     end
+  end
+
+  def self.nsenter(flag, options, &blk)
+    unless Object.const_get(:Process)
+      raise NotImplementedError, "Namespace.nsenter depends on mruby-process"
+    end
+
+    pid = Process.fork do
+      begin
+        ::Namespace.setns(flag, options)
+        blk.call
+      rescue => e
+        raise e
+        exit(127)
+      end
+    end
+
+    pid, s = Process.waitpid2 pid
+    unless s.success?
+      raise "nsenter process failed in some reason: PID=#{pid}, #{s.inspect}"
+    end
+    return s
   end
 end

--- a/mrblib/setns.rb
+++ b/mrblib/setns.rb
@@ -4,13 +4,14 @@ module Namespace
       return nsenter(flag, options, &blk)
     end
 
+    flag_ = ::Namespace.resolve_flag(flag)
     fd = options[:fd]
     pid = options[:pid]
 
     if fd
-      setns_by_fd(fd, flag)
+      setns_by_fd(fd, flag_)
     elsif pid
-      setns_by_pid(pid, flag)
+      setns_by_pid(pid, flag_)
     else
       raise ArgumentError, "Options :fd or :pid must be specified"
     end

--- a/test/test_setns.rb
+++ b/test/test_setns.rb
@@ -27,3 +27,34 @@ assert("Namespace.setns") do
     system "rm -rf /tmp/bar"
   end
 end
+
+assert("Namespace.nsenter") do
+  begin
+    system "mkdir -p /tmp/foo-2"
+    system "mkdir -p /tmp/bar-2"
+    system "touch /tmp/bar-2/test.txt"
+
+    pid1 = Process.fork do
+      Namespace.unshare(Namespace::CLONE_NEWNS)
+      system "mount --make-private /"
+      system "mount --bind /tmp/bar-2 /tmp/foo-2"
+      loop {}
+    end
+    sleep 0.5
+
+    ret = system "test -f /tmp/foo-2/test.txt"
+    assert_false ret
+
+    ns = Namespace.nsenter(Namespace::CLONE_NEWNS, :pid => pid1) {
+      ret = system "test -f /tmp/foo-2/test.txt"
+      system "umount /tmp/foo-2"
+      exit ret
+    }
+    assert_true ns.success?
+
+    Process.kill :TERM, pid1
+  ensure
+    system "rm -rf /tmp/foo-2"
+    system "rm -rf /tmp/bar-2"
+  end
+end


### PR DESCRIPTION
This enable it to work well:


```bash
cat <<RUBY | sudo ./mruby/bin/mruby
Namespace.nsenter(:net, fd: open('/var/run/netns/foobar')) do
  system 'ip a'
end
RUBY
1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
```