### PR TITLE
exit child process on error

### DIFF
--- a/mrblib/setns.rb
+++ b/mrblib/setns.rb
@@ -27,7 +27,6 @@ module Namespace
         ::Namespace.setns(flag, options)
         blk.call
       rescue => e
-        raise e
         exit(127)
       end
     end


### PR DESCRIPTION
Forked process never exit in block of `Process.fork` because there is `raise e` before `exit(127)`.
In mruby specification, child process seems to continue processing where raised error is caught.

In this case, child process continues outside `nsenter` method.

```ruby
::Namespace.nsenter(foo, bar) do 
  ...
end rescue nil

do_something # both child and parent eval this line when error in ::Namespace.nsenter
```

I simply deleted `raise` in order to fix this.